### PR TITLE
Switch to slice with unsafe index

### DIFF
--- a/dev/Cargo.lock
+++ b/dev/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "byte_reader"
-version = "1.2.1"
+version = "1.2.2"
 
 [[package]]
 name = "byte_reader_dev"

--- a/dev/tests/impl.rs
+++ b/dev/tests/impl.rs
@@ -1,0 +1,8 @@
+fn is_send<T: Send>() {}
+fn is_sync<T: Sync>() {}
+
+#[test]
+fn assert_impls() {
+    is_send::<byte_reader::Reader>();
+    is_sync::<byte_reader::Reader>();
+}

--- a/package/Cargo.lock
+++ b/package/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "byte_reader"
-version = "1.2.1"
+version = "1.2.2"

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "byte_reader"
-version       = "1.2.1"
+version       = "1.2.2"
 edition       = "2021"
 authors       = ["kanarus <kanarus786@gmail.com>"]
 documentation = "https://docs.rs/byte_reader"

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -17,4 +17,4 @@ location      = []
 text          = []
 
 ### DEBUG ###
-default = ["location", "text"]
+#default = ["location", "text"]

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -17,4 +17,4 @@ location      = []
 text          = []
 
 ### DEBUG ###
-#default = ["location", "text"]
+default = ["location", "text"]

--- a/package/src/lib.rs
+++ b/package/src/lib.rs
@@ -10,9 +10,6 @@ pub struct Reader<'b> {
     #[cfg(feature="location")] pub column: usize,
 }
 
-unsafe impl<'b> Send for Reader<'b> {}
-unsafe impl<'b> Sync for Reader<'b> {}
-
 impl<'b> Reader<'b> {
     pub fn new(content: &'b (impl AsRef<[u8]> + ?Sized)) -> Self {
         let buf = content.as_ref();


### PR DESCRIPTION
- Switch to hold entire the slice it self, instead of its pointer
- Using `[u8]::get_unchecked` for the same performance as previous version