### PR TITLE
success!!!

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,38 +59,13 @@ fn main() {
 
 You can track the reader's parsing location ( **line** and **column** ) in the input bytes.
 
-```rust
-/* activate "location" feature */
-use byte_reader::Reader;
-
-fn main() {
-    let mut r = Reader::new("Hello,    byte_reader!");
-
-    r.consume("Hello").unwrap();
-    r.consume(",").unwrap();
-    r.skip_whitespace();
-    let name_line   = r.line;   // 1
-    let name_column = r.column; // 11
-    let name_index  = r.index;  // 10
-    let name = r.read_snake().unwrap(); // "byte_reader"
-    r.consume("!").unwrap();
-
-    println!("Greeted to `{name}`.");
-    println!("In the input, the name starts at column {name_column} of line {name_line} (index: {index})");
-}
-```
-
 ### `"text"`
 
 Some utility methods for text-parsing are available：
 
-  - `read_quoted_by`
-  - `read_uint`, `read_int`
-  - `read_camel`, `read_snake`, `read_kebab`
-
-### `"detahced"` (**unsafe**)
-
-Make read bytes *detahced* in `read_*` operations. This resolves issue around borrowing `Reader`.
+- `read_quoted_by`
+- `read_uint`, `read_int`
+- `read_camel`, `read_snake`, `read_kebab`
 
 <br/>
 

--- a/package/Cargo.lock
+++ b/package/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "byte_reader"
-version = "2.1.0"
+version = "3.0.0"

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "byte_reader"
-version       = "2.1.0"
+version       = "3.0.0"
 edition       = "2021"
 authors       = ["kanarus <kanarus786@gmail.com>"]
 documentation = "https://docs.rs/byte_reader"
@@ -18,7 +18,6 @@ all-features  = true
 [features]
 location      = []
 text          = []
-detached      = []
 
 ### DEBUG ###
-#default = ["location", "text", "detached"]
+#default = ["location", "text"]

--- a/package/src/lib.rs
+++ b/package/src/lib.rs
@@ -1,9 +1,8 @@
 #![no_std]
-
 #![doc(html_root_url = "https://docs.rs/byte_reader")]
 
-pub struct Reader<'b> {
-    buf:  &'b [u8],
+pub struct Reader<'r> {
+    buf:  &'r [u8],
     size: usize,
     pub index: usize,
     /// **`location` feature required**\
@@ -14,12 +13,8 @@ pub struct Reader<'b> {
     #[cfg(feature="location")] pub column: usize,
 }
 
-#[inline(always)] pub const unsafe fn detatched<'d>(b: &[u8]) -> &'d [u8] {
-    unsafe {core::slice::from_raw_parts(b.as_ptr(), b.len())}
-}
-
-impl<'b> Reader<'b> {
-    pub fn new(buf: &'b [u8]) -> Self {
+impl<'r> Reader<'r> {
+    pub const fn new(buf: &'r [u8]) -> Self {
         Self {
             buf,
             size:  buf.len(),
@@ -93,19 +88,13 @@ impl<'b> Reader<'b> {
         self.skip_while(u8::is_ascii_whitespace)
     }
     /// Read next byte while the condition holds on it
-    #[inline] pub fn read_while<'x,
-        #[cfg(feature="detached")] 'r,
-        #[cfg(not(feature="detached"))] 'r: 'x,
-    >(&'r mut self, condition: impl Fn(&u8)->bool) -> &'x [u8] {
+    #[inline] pub fn read_while(&mut self, condition: impl Fn(&u8)->bool) -> &'r [u8] {
         let start = self.index;
         self.skip_while(condition);
-        unsafe {detatched(self.buf.get_unchecked(start..self.index))}
+        unsafe {self.buf.get_unchecked(start..self.index)}
     }
     /// Read through until the `pattern` comes in front of reader.
-    #[inline] pub fn read_until<'x,
-        #[cfg(feature="detached")] 'r,
-        #[cfg(not(feature="detached"))] 'r: 'x,
-    >(&'r mut self, pattern: &[u8]) -> &'x [u8] {
+    #[inline] pub fn read_until(&mut self, pattern: &[u8]) -> &'r [u8] {
         let start = self.index;
         let pat_len = pattern.len();
 
@@ -114,14 +103,14 @@ impl<'b> Reader<'b> {
             unsafe {
                 if self.buf.get_unchecked(i..i+pat_len) == pattern {
                     self.advance_unchecked_by(i - self.index);
-                    return detatched(self.buf.get_unchecked(start..self.index))
+                    return self.buf.get_unchecked(start..self.index)
                 }
             }
             i += 1
         }
 
         self.advance_unchecked_by(self.size - self.index);
-        unsafe {detatched(self.buf.get_unchecked(start..self.size))}
+        unsafe {self.buf.get_unchecked(start..self.size)}
     }
 
     /// Read next byte, or return None if the remaining bytes is empty
@@ -170,33 +159,24 @@ impl<'b> Reader<'b> {
 }
 
 #[cfg(feature="text")]
-impl<'b> Reader<'b> {
+impl<'r> Reader<'r> {
     /// **`text` feature required**\
     /// Read a `camelCase` word like `helloWorld`, `userID`, ... as `&str` if found
-    #[inline] pub fn read_camel<'x,
-        #[cfg(feature="detached")] 'r,
-        #[cfg(not(feature="detached"))] 'r: 'x,
-    >(&'r mut self) -> Option<&'x str> {
+    #[inline] pub fn read_camel(&mut self) -> Option<&'r str> {
         let ident_bytes = self.read_while(|b| matches!(b, b'a'..=b'z' | b'A'..=b'Z'));
         // SAFETY: `ident_bytes` is consists of `b'a'..=b'z' | b'A'..=b'Z'`
         (ident_bytes.len() > 0).then(|| unsafe {core::str::from_utf8_unchecked(ident_bytes)})
     }
     /// **`text` feature required**\
     /// Read a `snake_case` word like `hello_world`, `user_id`, ... as `&str` if found
-    #[inline] pub fn read_snake<'x,
-        #[cfg(feature="detached")] 'r,
-        #[cfg(not(feature="detached"))] 'r: 'x,
-    >(&'r mut self) -> Option<&'x str> {
+    #[inline] pub fn read_snake(&mut self) -> Option<&'r str> {
         let ident_bytes = self.read_while(|b| matches!(b, b'a'..=b'z' | b'A'..=b'Z' | b'_'));
         // SAFETY: `ident_bytes` is consists of `b'a'..=b'z' | b'A'..=b'Z' | b'_'`
         (ident_bytes.len() > 0).then(|| unsafe {core::str::from_utf8_unchecked(ident_bytes)})
     }
     /// **`text` feature required**\
     /// Read a `kebeb-case` word like `hello-world`, `Content-Type`, ... as `&str` if found
-    #[inline] pub fn read_kebab<'x,
-        #[cfg(feature="detached")] 'r,
-        #[cfg(not(feature="detached"))] 'r: 'x,
-    >(&'r mut self) -> Option<&'x str> {
+    #[inline] pub fn read_kebab(&mut self) -> Option<&'r str> {
         let ident_bytes = self.read_while(|b| matches!(b, b'a'..=b'z' | b'A'..=b'Z' | b'-'));
         // SAFETY: `ident_bytes` is consists of `b'a'..=b'z' | b'A'..=b'Z' | b'-'`
         (ident_bytes.len() > 0).then(|| unsafe {core::str::from_utf8_unchecked(ident_bytes)})
@@ -206,19 +186,16 @@ impl<'b> Reader<'b> {
     /// Read all bytes enclosed between `left` and `right`, then consume `left`, the bytes and `right`, and return the bytes.
     /// 
     /// Or, returns `None` if `left` or `right` is not found in remaining bytes.
-    #[inline] pub fn read_quoted_by<'x,
-        #[cfg(feature="detached")] 'r,
-        #[cfg(not(feature="detached"))] 'r: 'x,
-    >(&'r mut self, left: u8, right: u8) -> Option<&'x [u8]> {
+    #[inline] pub fn read_quoted_by(&mut self, left: u8, right: u8) -> Option<&'r [u8]> {
         if self.peek()? != &left {return None}
         let content_len = self.remaining()[1..].iter().take_while(|b| b != &&right).count();
         let eoq /* end of quotation */ = 0 + content_len + 1;
         if self.remaining().get(eoq)? != &right {return None}
 
         self.advance_unchecked_by(eoq + 1);
-        Some(unsafe {detatched(self.buf.get_unchecked(
+        Some(unsafe {self.buf.get_unchecked(
             (self.index - eoq)..(self.index - eoq + content_len)
-        ))})
+        )})
     }
 
     /// **`text` feature required**\

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "byte_reader"
-version = "2.1.0"
+version = "3.0.0"
 
 [[package]]
 name = "byte_reader_test"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-byte_reader = { version = "2.1", path = "../package" }
+byte_reader = { version = "3.0.0", path = "../package" }
 
 [features]
 text     = ["byte_reader/text"]
 location = ["byte_reader/location"]
-detached = ["byte_reader/detached"]

--- a/test/tests/test.rs
+++ b/test/tests/test.rs
@@ -129,7 +129,6 @@ use byte_reader::Reader;
     assert_eq!(r.column,     14);
 }
 
-#[cfg(feature="detached")]
 #[test] fn detached_ref() {
     let mut r = Reader::new(b"Hello, world!");
 


### PR DESCRIPTION
Returning `&'r [u8]` from `Reader<'r>` is the correct way to avoid the issue around borrowing `Reader`, it enable to remove `"detached"` feature and unsafe lifetime manipulations.